### PR TITLE
Bug fix for wrong order of positional arguments in any-layer.R example

### DIFF
--- a/_examples/any-layer.R
+++ b/_examples/any-layer.R
@@ -23,4 +23,4 @@ properties <- list(
 layer_class <- "PolygonLayer"
 
 deckgl(zoom = 10, pitch = 35) %>%
-  add_layer(layer_class, "polygon-layer", data, properties)
+  add_layer(layer_class, "polygon-layer", data=data, properties=properties)

--- a/_examples/multiple-layers.R
+++ b/_examples/multiple-layers.R
@@ -5,18 +5,19 @@ bart_stations <- system.file("sample-data/bart-stations.json", package = "deckgl
 main_properties <- list(
   getPosition = get_position("lat", "lng")
 )
+SOURCE_ID = 'bart-stations'
 
 deckgl(zoom = 10, pitch = 35) %>%
-  add_data(bart_stations) %>%
+  add_source(SOURCE_ID, data=bart_stations) %>%
   add_scatterplot_layer(
-    data = get_data(),
+    source=SOURCE_ID,
     properties = main_properties,
     radiusScale = 6,
     getRadius = 50,
     getColor = c(240, 140, 20)
   ) %>%
   add_text_layer(
-    data = get_data(),
+    source=SOURCE_ID,
     properties = main_properties,
     getText = get_property("name"),
     getAlignmentBaseline = "bottom"


### PR DESCRIPTION
With %>% piping, the example's existing code passes `data`, not `properties`, as the fourth positional argument, which raises the following error:
Error in utils::modifyList(., properties) : is.list(val) is not TRUE